### PR TITLE
Add mtu configuration to sriov_pfs and bonds

### DIFF
--- a/switchdev_utils/config-service/README.md
+++ b/switchdev_utils/config-service/README.md
@@ -33,11 +33,13 @@ List of SRIOV PF objects which need to be configured, and has the following attr
     - numOfVfs: Number of vfs to be configured on the sriov pf.  
     - switchdev: Boolean, Enable switchdev mode.  
     - vfTrust: Boolean, Configure vf trust.  
+    - mtu: Number, configure mtu for sriov_pf (it will be ignored if sriov_pf is a bond slave)
 - linuxBonds:  
 list of linux bond objects which need to be created and configured  
     - name: The name of the bond interface  
     - slaves: List of bond slaves interfaces (a subset of sriov pfs)  
     - bondingOptions: Bonding options of the bond interface  
+    - mtu: Number, configure mtu for bond interface and its slaves
 - ovsBridges:  
 List of ovs bridges which need to be created and configured  
     - name: The name of ovs bridge  

--- a/switchdev_utils/config-service/README.md
+++ b/switchdev_utils/config-service/README.md
@@ -44,6 +44,10 @@ list of linux bond objects which need to be created and configured
 List of ovs bridges which need to be created and configured  
     - name: The name of ovs bridge  
     - ports: List of ovs bridge ports (a subset of sriov pfs or linux bonds)  
+**Note:**
+  - Configure mtu for sriov_pf will be ignored if sriov_pf is a bond slave
+  - Configure mtu for bond interface will configure it to its slaves
+  - Configure mtu for sriov_pf will set it to the brdige if sriov_pf is ovs port
 
 ## Install  
 Prepare your own config.yaml file with all the configuration you need and pass it to installation script or you can copy it directly to `/etc/switchdev-config/config.yaml` before execution  

--- a/switchdev_utils/config-service/sample_config.yaml
+++ b/switchdev_utils/config-service/sample_config.yaml
@@ -8,24 +8,25 @@ pfs:
   - name: ens2f1
     numOfVfs: 8
     switchdev: True
-    vfTrust: True 
+    vfTrust: True
   - name: ens1f0
     numOfVfs: 8
     switchdev: True
     vfTrust: True
+    mtu: 9000
   - name: ens1f1
     numOfVfs: 8
     switchdev: True
     vfTrust: True
+    mtu: 9000
 linuxBonds:
   - name: bond0
     slaves: [ens2f0, ens2f1]
     bondingOptions: "mode=802.3ad miimon=100 lacp_rate=fast xmit_hash_policy=layer2+3"
-  - name: bond1
-    slaves: [ens1f0, ens1f1]
-    bondingOptions: "mode=802.3ad miimon=100 lacp_rate=fast xmit_hash_policy=layer2+3"
+    mtu: 9000
+
 ovsBridges:
   - name: br0
     ports:  [bond0]
   - name: br1
-    ports: [bond1]
+    ports: [ens1f0]

--- a/switchdev_utils/config-service/switchdev_network_config
+++ b/switchdev_utils/config-service/switchdev_network_config
@@ -572,19 +572,18 @@ def validate_config(config):
         try:
             int(sriov_pf.get("numOfVfs"))
         except ValueError as value_err:
-            err = "numOfVfs for %s must be number" % sriov_pf.get("name")
-            logger.error(err)
+            logger.error("numOfVfs for %s must be number" %
+                         sriov_pf.get("name"))
             raise value_err
         except TypeError as type_err:
-            err = "numOfVfs for %s must be provided" % sriov_pf.get("name")
-            logger.error(err)
+            logger.error("numOfVfs for %s must be provided" %
+                         sriov_pf.get("name"))
             raise type_err
         if sriov_pf.get("mtu"):
             try:
                 int(sriov_pf.get("mtu"))
             except ValueError as value_err:
-                err = "mtu %s must be number" % sriov_pf.get("mtu")
-                logger.error(err)
+                logger.error("mtu %s must be number" % sriov_pf.get("mtu"))
                 raise value_err
 
     for bond in config.get("linuxBonds"):
@@ -611,8 +610,7 @@ def validate_config(config):
             try:
                 int(bond.get("mtu"))
             except ValueError as value_err:
-                err = "mtu %s must be number" % bond.get("mtu")
-                logger.error(err)
+                logger.error("mtu %s must be number" % bond.get("mtu"))
                 raise value_err
     for bridge in config.get("ovsBridges"):
         if not bridge.get("name"):
@@ -667,6 +665,8 @@ def main(argv=sys.argv):
     hw_offload_enabled = config.get("hwOffloadEnabled")
 
     if (not opts.sriov_config and not opts.sriov_bind):
+        # Running switchdev network config for the first time
+        logger.info("Running switchdev network config for the first time")
         # Configure sriov pfs
         configure_sriov_pfs(sriov_pfs)
         configure_sriov_config_service()

--- a/switchdev_utils/config-service/switchdev_network_config
+++ b/switchdev_utils/config-service/switchdev_network_config
@@ -388,6 +388,8 @@ def configure_sriov_pfs(sriov_pfs, from_sriov_service=False):
         if not from_sriov_service:
             sriov_pf_data = "%sDEVICE=%s\n" % (COMMON_IFCFG_DATA,
                                                sriov_pf_name)
+            if sriov_pf.get("mtu"):
+                sriov_pf_data += "MTU=%s\n" % sriov_pf.get("mtu")
             ifcfg_interfaces_map[sriov_pf_name] = sriov_pf_data
     if rep_link_name_script:
         create_rep_link_name_script()
@@ -416,6 +418,8 @@ def configure_linux_bonds(linux_bonds):
         bond_data = "%s%sDEVICE=%s\n" % (COMMON_IFCFG_DATA,
                                          bonding_options_data,
                                          bond)
+        if linux_bond.get("mtu"):
+            bond_data += "MTU=%s\n" % linux_bond.get("mtu")
         ifcfg_interfaces_map[bond] = bond_data
         slaves_data = "SLAVE=yes\nMASTER=%s\n" % bond
         for slave in bond_slaves:
@@ -566,15 +570,23 @@ def validate_config(config):
             logger.error(err)
             raise ValueError(err)
         try:
-            if int(sriov_pf.get("numOfVfs")):
-                continue
+            int(sriov_pf.get("numOfVfs"))
         except ValueError as value_err:
-            logger.error("numOfVfs for %s must be number" %
-                         sriov_pf.get("name"))
+            err = "numOfVfs for %s must be number" % sriov_pf.get("name")
+            logger.error(err)
             raise value_err
         except TypeError as type_err:
-            logger.error("numOfVfs for %s must be provided" %
-                         sriov_pf.get("name"))
+            err = "numOfVfs for %s must be provided" % sriov_pf.get("name")
+            logger.error(err)
+            raise type_err
+        if sriov_pf.get("mtu"):
+            try:
+                int(sriov_pf.get("mtu"))
+            except ValueError as value_err:
+                err = "mtu %s must be number" % sriov_pf.get("mtu")
+                logger.error(err)
+                raise value_err
+
     for bond in config.get("linuxBonds"):
         if bond.get("name"):
             bonds_list.append(bond.get("name"))
@@ -589,12 +601,19 @@ def validate_config(config):
             raise ValueError(err)
         if (bond.get("slaves") and
                 (set(bond.get("slaves")).issubset(set(sriov_pfs_list)))):
-            continue
+            pass
         else:
             err = "slaves of bond %s must be list of sriov_pfs" % \
                   bond.get("name")
             logger.error(err)
             raise ValueError(err)
+        if bond.get("mtu"):
+            try:
+                int(bond.get("mtu"))
+            except ValueError as value_err:
+                err = "mtu %s must be number" % bond.get("mtu")
+                logger.error(err)
+                raise value_err
     for bridge in config.get("ovsBridges"):
         if not bridge.get("name"):
             err = "bridge name must be provided"

--- a/switchdev_utils/config-service/switchdev_network_config
+++ b/switchdev_utils/config-service/switchdev_network_config
@@ -600,7 +600,7 @@ def validate_config(config):
             raise ValueError(err)
         if (bond.get("slaves") and
                 (set(bond.get("slaves")).issubset(set(sriov_pfs_list)))):
-            pass
+            logger.debug("bond slaves are provided from sriov_pfs")
         else:
             err = "slaves of bond %s must be list of sriov_pfs" % \
                   bond.get("name")
@@ -620,7 +620,7 @@ def validate_config(config):
         if (bridge.get("ports") and
                 (set(bridge.get("ports")).issubset(set(sriov_pfs_list +
                                                    bonds_list)))):
-            continue
+            logger.debug("bridge ports are provided from sriov_pfs or bonds")
         else:
             err = "ports of bridge %s must be list of sriov_pfs or bonds" % \
                   bridge.get("name")


### PR DESCRIPTION
Allow seting mtu for sriov_pfs and bonds, but please note that:
  - Configure mtu for sriov_pf will be ignored if sriov_pf is a bond slave
  - Configure mtu for bond interface will configure it to its slaves
  - Configure mtu for sriov_pf will set it to the brdige if sriov_pf is ovs port